### PR TITLE
Adding an out of bound check for scry hotkey

### DIFF
--- a/src/main/java/test447/keycuts/patches/cards/GridCardSelectScreenPatches.java
+++ b/src/main/java/test447/keycuts/patches/cards/GridCardSelectScreenPatches.java
@@ -68,6 +68,10 @@ public class GridCardSelectScreenPatches
 				if (InputActionSet.selectCardActions[i].isJustPressed())
 				{
 					int cardPosition = CARDS_PER_LINE * row + i;
+					if(cardPosition >= self.targetGroup.group.length || cardPosition < 0){
+						// card out of range
+						return;
+					}
 					AbstractCard hoveredCard = self.targetGroup.group.get(cardPosition);
 					hoveredCard.hb.clicked = true;
 					ReflectionHacks.setPrivate(self, GridCardSelectScreen.class, "hoveredCard", hoveredCard);


### PR DESCRIPTION
regarding this error that happens when you try to hotkey a scry card number that is higher than the number of cards shown to you: 
```java.lang.IndexOutOfBoundsException: Index: 3, Size: 3
	at java.util.ArrayList.rangeCheck(ArrayList.java:657)
	at java.util.ArrayList.get(ArrayList.java:433)
	at test447.keycuts.patches.cards.GridCardSelectScreenPatches$Update.Insert(GridCardSelectScreenPatches.java:71)
	at com.megacrit.cardcrawl.screens.select.GridCardSelectScreen.update(GridCardSelectScreen.java:143)
	at com.megacrit.cardcrawl.dungeons.AbstractDungeon.update(AbstractDungeon.java:2564)
	at com.megacrit.cardcrawl.core.CardCrawlGame.update(CardCrawlGame.java:876)
	at com.megacrit.cardcrawl.core.CardCrawlGame.render(CardCrawlGame.java:423)
	at com.badlogic.gdx.backends.lwjgl.LwjglApplication.mainLoop(LwjglApplication.java:225)
	at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:126)```